### PR TITLE
NDEV-20461 : support for private image registry for kube-bench

### DIFF
--- a/pkg/kubebench/kubebench.go
+++ b/pkg/kubebench/kubebench.go
@@ -50,7 +50,7 @@ func RunJob(params *params.KubeBenchArgs) (*kubebench.OverallControls, error) {
 		return nil, err
 	}
 
-	if params.Registry != "aquasec" {
+	if params.Registry != "aquasec" && params.RegistryUsername != "" && params.RegistryPassword != "" {
 		secretName, err := deploySecret(context.Background(), clientset, params)
 		if err != nil {
 			return nil, err
@@ -62,6 +62,16 @@ func RunJob(params *params.KubeBenchArgs) (*kubebench.OverallControls, error) {
 			fmt.Printf("failed to find secret for job %s\n", err)
 			return nil, err
 		}
+	} else {
+		requiredParam := make([]string, 2)
+		if params.Registry != "aquasec" && params.RegistryUsername == "" {
+			requiredParam = append(requiredParam, "registry-username")
+		} 
+		
+		if params.Registry != "aquasec" && params.RegistryPassword == "" {
+			requiredParam = append(requiredParam, "registry-password")
+		}
+		fmt.Printf("failed to create imagePullSecret, pls specify required params %s\n", requiredParam)
 	}
 
 	var jobName string

--- a/pkg/kubebench/kubebench.go
+++ b/pkg/kubebench/kubebench.go
@@ -50,6 +50,20 @@ func RunJob(params *params.KubeBenchArgs) (*kubebench.OverallControls, error) {
 		return nil, err
 	}
 
+	if params.Registry != "aquasec" {
+		secretName, err := deploySecret(context.Background(), clientset, params)
+		if err != nil {
+			return nil, err
+		}
+
+		_, err = clientset.CoreV1().Secrets(params.Namespace).Get(context.Background(), secretName, metav1.GetOptions{})
+
+		if err != nil {
+			fmt.Printf("failed to find secret for job %s\n", err)
+			return nil, err
+		}
+	}
+
 	var jobName string
 	jobName, err = deployJob(context.Background(), clientset, params)
 	if err != nil {
@@ -86,6 +100,29 @@ func RunJob(params *params.KubeBenchArgs) (*kubebench.OverallControls, error) {
 	return controls, nil
 }
 
+func deploySecret(ctx context.Context, clientset *kubernetes.Clientset, params *params.KubeBenchArgs) (string, error) {
+	// Create a new secret object
+	secret := &apiv1.Secret{
+		Type: apiv1.SecretTypeOpaque,
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "docker-image-pull-secret",
+			Namespace: params.Namespace,
+		},
+		Data: map[string][]byte{
+			".dockerconfigjson": []byte(`{"auths":{"` + params.Registry + `":{"username":"` + params.RegistryUsername + `","password":"` + params.RegistryPassword + `"}}}`),
+		},
+	}
+
+	// Create the secret in the Kubernetes cluster
+	_, err := clientset.CoreV1().Secrets(params.Namespace).Create(ctx, secret, metav1.CreateOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	// Return the name of the created secret
+	return secret.Name, nil
+}
+
 func deployJob(ctx context.Context, clientset *kubernetes.Clientset, params *params.KubeBenchArgs) (string, error) {
 	jobYAML, err := embedYAMLs(params.KubebenchBenchmark, params.ClusterType, params.CustomJobFile)
 	if err != nil {
@@ -97,8 +134,9 @@ func deployJob(ctx context.Context, clientset *kubernetes.Clientset, params *par
 	if err := decoder.Decode(job); err != nil {
 		return "", err
 	}
+	kubebenchImg := params.Registry + "/kube-bench:" + params.KubebenchTag
 	jobName := job.GetName()
-	job.Spec.Template.Spec.Containers[0].Image = params.KubebenchImg
+	job.Spec.Template.Spec.Containers[0].Image = kubebenchImg
 	job.Spec.Template.Spec.Containers[0].Args = []string{"--json"}
 	if params.KubebenchBenchmark != "" {
 		job.Spec.Template.Spec.Containers[0].Args = append(job.Spec.Template.Spec.Containers[0].Args, "--benchmark="+params.KubebenchBenchmark)

--- a/pkg/params/parse.go
+++ b/pkg/params/parse.go
@@ -14,12 +14,15 @@ type KubeBenchArgs struct {
 	Name string
 
 	Kubeconfig         string
-	KubebenchImg       string
+	KubebenchTag       string
 	KubebenchTargets   string
 	KubebenchVersion   string
 	KubebenchBenchmark string
 	CustomJobFile      string
 	ClusterType        string
+	Registry           string
+	RegistryUsername   string
+	RegistryPassword   string
 
 	Timeout time.Duration
 
@@ -38,7 +41,10 @@ func ParseArguments() {
 	flag.StringVar(&Params.CustomJobFile, "custom-job-file", "", "specify a custom kubebench job file if any")
 	flag.StringVar(&Params.ClusterType, "cluster-type-override", "", "use non default cluster type in kube-bench, E.g aks, eks, eks-asff, gke, etc.")
 
-	flag.StringVar(&Params.KubebenchImg, "kube-bench-image", "aquasec/kube-bench:v0.6.17", "kube-bench image used as part of this test")
+	flag.StringVar(&Params.KubebenchTag, "tag", "v0.6.17", "kube-bench image tag used as part of this test")
+	flag.StringVar(&Params.Registry, "registry-name", "aquasec", "registry where kube-bench image resides")
+	flag.StringVar(&Params.RegistryUsername, "registry-username", "", "registry user name")
+	flag.StringVar(&Params.RegistryPassword, "registry-password", "", "registry password")
 	flag.DurationVar(&Params.Timeout, "timeout", 10*time.Minute, "Test Timeout")
 	flag.StringVar(&Params.NodeSelectorKey, "nodeSelectorKey", "", "Job nameSelector Key")
 	flag.StringVar(&Params.NodeSelectorValue, "nodeSelectorValue", "", "Job nameSelector value")


### PR DESCRIPTION
This PR introduces the support for the kube-bench adapter to pull the kube-bench image from private registry.

parameters required:

```
-registry-name
-registry-username
-registry-password
```

Also changed the parameter from kube-bench-image to tag to support loose coupling.
